### PR TITLE
Refactor logging + startup enhancements

### DIFF
--- a/src/renderer/components/Dashboard/Project.vue
+++ b/src/renderer/components/Dashboard/Project.vue
@@ -158,6 +158,8 @@ export default {
       this.projectStatus = status.RESTARTING;
       this.startProcess(() => this.$docker.restartProject(this.project.dir))
         .then(() => {
+          // For some reason, the logs persist from the previous running app?
+          // So we don't need to call startLogs() again.
           this.projectStatus = status.RUNNING;
           this.$store.dispatch("fetchContainers");
         })

--- a/src/renderer/components/Dashboard/Project.vue
+++ b/src/renderer/components/Dashboard/Project.vue
@@ -241,6 +241,7 @@ export default {
     ...mapGetters(["containers", "activeProject"])
   },
   created() {
+    // There is a delay on this for some reason.
     setTimeout(() => {
       if (this.running || this.partiallyRunning) {
         this.startLogs();
@@ -259,6 +260,17 @@ export default {
       if (newProjectId == this.project.id) {
         this.setTabAreaHeight();
       }
+    },
+    running(value) {
+      // Attempt to catch a project started outside of Lifeboat and watch the logs
+      setTimeout(() => {
+        if (value && !this.process) {
+          console.log(
+            `Starting logs for ${this.project.name} outside Lifeboat`
+          );
+          this.startLogs();
+        }
+      }, 1000);
     }
   }
 };

--- a/src/renderer/components/Dashboard/Project.vue
+++ b/src/renderer/components/Dashboard/Project.vue
@@ -123,7 +123,7 @@ export default {
     return {
       activeTab: "logs",
       projectStatus: status.STOPPED,
-      logs: "",
+      logs: "Click Start to see project logs!",
       process: null
     };
   },
@@ -132,6 +132,7 @@ export default {
       return this.project.containers().find(c => c.service === service);
     },
     start() {
+      this.logs = "";
       this.projectStatus = status.STARTING;
 
       this.startProcess(() => this.$docker.startProject(this.project.dir))
@@ -195,6 +196,7 @@ export default {
      * Start getting logs for an already-running project
      */
     startLogs() {
+      this.logs = "";
       this.process = this.$docker.logs(this.project.dir);
       this.logProcess();
     },

--- a/src/renderer/components/Dashboard/ProjectLog.vue
+++ b/src/renderer/components/Dashboard/ProjectLog.vue
@@ -6,8 +6,6 @@
 <script>
 import { mapGetters } from "vuex";
 import AU from "ansi_up";
-import events from "@/utils/events";
-import Mousetrap from "mousetrap";
 import scrollToBottom from "@/mixins/scroll-to-bottom";
 
 const ansi_up = new AU();

--- a/src/renderer/components/Dashboard/ProjectLog.vue
+++ b/src/renderer/components/Dashboard/ProjectLog.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapGetters } from "vuex";
 import AU from "ansi_up";
 import events from "@/utils/events";
 import Mousetrap from "mousetrap";
@@ -14,11 +14,10 @@ const ansi_up = new AU();
 let logger;
 
 export default {
-  props: ["project"],
+  props: ["project", "logs"],
   mixins: [scrollToBottom],
   data() {
     return {
-      logs: "",
       isScrolledUp: false
     };
   },
@@ -26,52 +25,14 @@ export default {
     logOutput() {
       return ansi_up.ansi_to_html(this.logs);
     },
-    ...mapState({
-      activeProject: state => state.App.activeProject
-    })
-  },
-  methods: {
-    addLogs(logs) {
-      this.logs += logs;
-      this.scrollToBottom();
-    },
-    clearLogs() {
-      this.logs = "";
-    },
-    startLogger() {
-      this.logs = "";
-
-      logger = this.$docker.logs(this.project.dir);
-      logger.stdout.on("data", data => {
-        this.addLogs(data.toString());
-      });
-    },
-    killLogger() {
-      if (logger) logger.kill();
-    }
-  },
-  created() {
-    this.startLogger();
-
-    let timer;
-
-    events.$on("PROJECT_STARTED", () => {
-      timer = setTimeout(this.startLogger, 2000);
-    });
-
-    events.$on("PROJECT_ERRORED", e => {
-      clearTimeout(timer);
-      this.addLogs(e);
-    });
-
-    Mousetrap.bind("meta+k", this.clearLogs);
-  },
-  beforeDestroy() {
-    this.killLogger();
+    ...mapGetters(["activeProject"])
   },
   watch: {
-    activeProject(newProject) {
-      if (newProject == this.project) {
+    logs() {
+      this.scrollToBottom();
+    },
+    activeProject(newProjectId) {
+      if (newProjectId == this.project.id) {
         this.scrollToBottom();
       }
     }

--- a/src/renderer/store/modules/App.js
+++ b/src/renderer/store/modules/App.js
@@ -38,6 +38,9 @@ const actions = {
 const getters = {
   containers(state) {
     return state.containers;
+  },
+  activeProject(state) {
+    return state.activeProject;
   }
 };
 

--- a/src/renderer/utils/docker.js
+++ b/src/renderer/utils/docker.js
@@ -9,7 +9,15 @@ export default class Docker {
    * @param {string} dir
    */
   startProject(dir) {
-    return DockerCompose.async(dir, ["up", "-d"]);
+    return DockerCompose.sync(dir, ["up", "-d"]);
+  }
+
+  /**
+   * Builds a Docker Compose project
+   * @param {string} dir
+   */
+  buildProject(dir) {
+    return DockerCompose.sync(dir, ["build"]);
   }
 
   /**
@@ -17,7 +25,7 @@ export default class Docker {
    * @param {string} dir
    */
   stopProject(dir) {
-    return DockerCompose.async(dir, ["down"]);
+    return DockerCompose.sync(dir, ["down"]);
   }
 
   /**
@@ -25,7 +33,7 @@ export default class Docker {
    * @param {string} dir
    */
   restartProject(dir) {
-    return DockerCompose.async(dir, ["restart"]);
+    return DockerCompose.sync(dir, ["restart"]);
   }
 
   /**


### PR DESCRIPTION
This PR overhauls the lifecycle of a project. 

- Moves log-watching to a responsibility of the Project. `logs` get passed down to `ProjectLog` as a prop.
- Smartly checks for an already-running project and then checks logs on boot. Fixes #7.
- Logs direct output of commands, so we can see containers being built and fetched. Fixes #18.
- Adds a `Build and Start` option, so projects can be built prior to being started. Fixes #19.
- Removes the ability to clear a log since it wasn't working well. We can revisit when we add more features to log display, like truncation, filtering, etc. #12 
